### PR TITLE
Add a new Counter option to allow multiple field values per point

### DIFF
--- a/Tharga.Influx-Capacitor.Collector.Tests/CollectorEngineTests/RegisterCounterValuesTests.cs
+++ b/Tharga.Influx-Capacitor.Collector.Tests/CollectorEngineTests/RegisterCounterValuesTests.cs
@@ -21,7 +21,7 @@ namespace Tharga.InfluxCapacitor.Collector.Tests.CollectorEngineTests
             performanceCounterGroupMock.SetupGet(x => x.SecondsInterval).Returns(1);
             performanceCounterGroupMock.SetupGet(x => x.RefreshInstanceInterval).Returns(1);
             performanceCounterGroupMock.SetupGet(x => x.Name).Returns("A");
-            performanceCounterGroupMock.Setup(x => x.GetFreshCounters()).Returns(new List<IPerformanceCounterInfo> { new PerformanceCounterInfo(string.Empty, new PerformanceCounter("Processor", "% Processor Time", "_Total"), null, null) });
+            performanceCounterGroupMock.Setup(x => x.GetFreshCounters()).Returns(new List<IPerformanceCounterInfo> { new PerformanceCounterInfo(string.Empty, new PerformanceCounter("Processor", "% Processor Time", "_Total"), null, null, null) });
             performanceCounterGroupMock.SetupGet(x => x.Tags).Returns(new ITag[] { });
             var sendBusinessMock = new Mock<ISendBusiness>(MockBehavior.Strict);
             sendBusinessMock.Setup(x => x.Enqueue(It.IsAny<Point[]>()));

--- a/Tharga.Influx-Capacitor.Collector.Tests/CollectorEngineTests/RegisterCounterValuesTests.cs
+++ b/Tharga.Influx-Capacitor.Collector.Tests/CollectorEngineTests/RegisterCounterValuesTests.cs
@@ -63,5 +63,65 @@ namespace Tharga.InfluxCapacitor.Collector.Tests.CollectorEngineTests
             sendBusinessMock.Verify(x => x.Enqueue(It.IsAny<Point[]>()), Times.Once);
             Assert.That(response, Is.EqualTo(0));
         }
+
+        [Test]
+        public void Should_send_multiple_points_when_not_using_fieldname()
+        {
+            //Arrange
+            string databaseName = "AA";
+            var performanceCounterGroupMock = new Mock<IPerformanceCounterGroup>(MockBehavior.Strict);
+            performanceCounterGroupMock.SetupGet(x => x.SecondsInterval).Returns(1);
+            performanceCounterGroupMock.SetupGet(x => x.RefreshInstanceInterval).Returns(1);
+            performanceCounterGroupMock.SetupGet(x => x.Name).Returns("cpu");
+            performanceCounterGroupMock.Setup(x => x.GetFreshCounters()).Returns(new List<IPerformanceCounterInfo>
+            {
+                new PerformanceCounterInfo(string.Empty, new PerformanceCounter("Processor", "% Processor Time", "_Total"), null, null, null),
+                new PerformanceCounterInfo(string.Empty, new PerformanceCounter("Processor", "% Idle Time", "_Total"), null, null, null)
+            });
+            performanceCounterGroupMock.SetupGet(x => x.Tags).Returns(new ITag[] { });
+            var sendBusinessMock = new Mock<ISendBusiness>(MockBehavior.Strict);
+            sendBusinessMock.Setup(x => x.Enqueue(It.IsAny<Point[]>()));
+            var tagLaoderMock = new Mock<ITagLoader>(MockBehavior.Strict);
+            tagLaoderMock.Setup(x => x.GetGlobalTags()).Returns(new[] { Mock.Of<ITag>(x => x.Name == "B") });
+            var collectorEngine = new ExactCollectorEngine(performanceCounterGroupMock.Object, sendBusinessMock.Object, tagLaoderMock.Object, false);
+
+            //Act
+            var response = collectorEngine.CollectRegisterCounterValuesAsync().Result;
+
+            //Assert
+            tagLaoderMock.Verify(x => x.GetGlobalTags(), Times.Once);
+            sendBusinessMock.Verify(x => x.Enqueue(It.IsAny<Point[]>()), Times.Once);
+            Assert.That(response, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Should_send_one_point_when_using_fieldname()
+        {
+            //Arrange
+            string databaseName = "AA";
+            var performanceCounterGroupMock = new Mock<IPerformanceCounterGroup>(MockBehavior.Strict);
+            performanceCounterGroupMock.SetupGet(x => x.SecondsInterval).Returns(1);
+            performanceCounterGroupMock.SetupGet(x => x.RefreshInstanceInterval).Returns(1);
+            performanceCounterGroupMock.SetupGet(x => x.Name).Returns("cpu");
+            performanceCounterGroupMock.Setup(x => x.GetFreshCounters()).Returns(new List<IPerformanceCounterInfo>
+            {
+                new PerformanceCounterInfo(string.Empty, new PerformanceCounter("Processor", "% Processor Time", "_Total"), "processor_pct_active", null, null),
+                new PerformanceCounterInfo(string.Empty, new PerformanceCounter("Processor", "% Idle Time", "_Total"), "processor_pct_idle", null, null)
+            });
+            performanceCounterGroupMock.SetupGet(x => x.Tags).Returns(new ITag[] { });
+            var sendBusinessMock = new Mock<ISendBusiness>(MockBehavior.Strict);
+            sendBusinessMock.Setup(x => x.Enqueue(It.IsAny<Point[]>()));
+            var tagLaoderMock = new Mock<ITagLoader>(MockBehavior.Strict);
+            tagLaoderMock.Setup(x => x.GetGlobalTags()).Returns(new[] { Mock.Of<ITag>(x => x.Name == "B") });
+            var collectorEngine = new ExactCollectorEngine(performanceCounterGroupMock.Object, sendBusinessMock.Object, tagLaoderMock.Object, false);
+
+            //Act
+            var response = collectorEngine.CollectRegisterCounterValuesAsync().Result;
+
+            //Assert
+            tagLaoderMock.Verify(x => x.GetGlobalTags(), Times.Once);
+            sendBusinessMock.Verify(x => x.Enqueue(It.IsAny<Point[]>()), Times.Once);
+            Assert.That(response, Is.EqualTo(1));
+        }
     }
 }

--- a/Tharga.Influx-Capacitor.Collector.Tests/CollectorEngineTests/StartTests.cs
+++ b/Tharga.Influx-Capacitor.Collector.Tests/CollectorEngineTests/StartTests.cs
@@ -43,7 +43,7 @@ namespace Tharga.InfluxCapacitor.Collector.Tests.CollectorEngineTests
             var performanceCounterGroupMock = new Mock<IPerformanceCounterGroup>(MockBehavior.Strict);
             performanceCounterGroupMock.SetupGet(x => x.SecondsInterval).Returns(1);
             performanceCounterGroupMock.SetupGet(x => x.Name).Returns("A");
-            performanceCounterGroupMock.Setup(x => x.GetFreshCounters()).Returns(new List<IPerformanceCounterInfo> { new PerformanceCounterInfo(string.Empty, new PerformanceCounter("Processor", "% Processor Time", "_Total"), null, null) });
+            performanceCounterGroupMock.Setup(x => x.GetFreshCounters()).Returns(new List<IPerformanceCounterInfo> { new PerformanceCounterInfo(string.Empty, new PerformanceCounter("Processor", "% Processor Time", "_Total"), null, null, null) });
             var sendBusinessMock = new Mock<ISendBusiness>(MockBehavior.Strict);
             var tagLaoderMock = new Mock<ITagLoader>(MockBehavior.Strict);
             var collectorEngine = new ExactCollectorEngine(performanceCounterGroupMock.Object, sendBusinessMock.Object, tagLaoderMock.Object, false);
@@ -64,7 +64,7 @@ namespace Tharga.InfluxCapacitor.Collector.Tests.CollectorEngineTests
             var performanceCounterGroupMock = new Mock<IPerformanceCounterGroup>(MockBehavior.Strict);
             performanceCounterGroupMock.SetupGet(x => x.SecondsInterval).Returns(1);
             performanceCounterGroupMock.SetupGet(x => x.Name).Returns("A");
-            performanceCounterGroupMock.Setup(x => x.GetFreshCounters()).Returns(new List<IPerformanceCounterInfo> { new PerformanceCounterInfo(string.Empty, new PerformanceCounter("Processor", "% Processor Time", "_Total"), null, null) });
+            performanceCounterGroupMock.Setup(x => x.GetFreshCounters()).Returns(new List<IPerformanceCounterInfo> { new PerformanceCounterInfo(string.Empty, new PerformanceCounter("Processor", "% Processor Time", "_Total"), null, null, null) });
             var sendBusinessMock = new Mock<ISendBusiness>(MockBehavior.Strict);
             var tagLaoderMock = new Mock<ITagLoader>(MockBehavior.Strict);
             var collectorEngine = new ExactCollectorEngine(performanceCounterGroupMock.Object, sendBusinessMock.Object, tagLaoderMock.Object, false);

--- a/Tharga.Influx-Capacitor.Collector/Business/ConfigBusiness.cs
+++ b/Tharga.Influx-Capacitor.Collector/Business/ConfigBusiness.cs
@@ -424,6 +424,7 @@ namespace Tharga.InfluxCapacitor.Collector.Business
             string counterName = null;
             string instanceName = null;
             string instanceAlias = null;
+            string fieldName = null;
 
             var tags = new List<ITag>();
             var tagElements1 = counter.GetElementsByTagName("CounterTag");
@@ -451,10 +452,13 @@ namespace Tharga.InfluxCapacitor.Collector.Business
                         instanceName = item.InnerText;
                         instanceAlias = item.GetAttribute("Alias");
                         break;
+                    case "FieldName":
+                        fieldName = item.InnerText;
+                        break;
                 }
             }
 
-            return new Counter(categoryName, counterName, instanceName, instanceAlias, tags);
+            return new Counter(categoryName, counterName, instanceName, fieldName, instanceAlias, tags);
         }
 
         private static ApplicationConfig GetApplicationConfig(XmlDocument document)
@@ -697,6 +701,14 @@ namespace Tharga.InfluxCapacitor.Collector.Business
                     var instanceName = document.CreateElement("InstanceName");
                     instanceName.InnerText = counter.InstanceName;
                     counterElement.AppendChild(instanceName);
+
+                    // we add the "FieldName" element only if a value is specified
+                    if (!string.IsNullOrEmpty(counter.FieldName))
+                    {
+                        var fieldName = document.CreateElement("FieldName");
+                        fieldName.InnerText = counter.FieldName;
+                        counterElement.AppendChild(fieldName);
+                    }
                 }
             }
 

--- a/Tharga.Influx-Capacitor.Collector/Business/CounterBusiness.cs
+++ b/Tharga.Influx-Capacitor.Collector/Business/CounterBusiness.cs
@@ -48,12 +48,12 @@ namespace Tharga.InfluxCapacitor.Collector.Business
                             name = performanceCounter.InstanceName;
                         }
 
-                        performanceCounterInfos.Add(new PerformanceCounterInfo(name, performanceCounter, counter.Alias, counter.Tags));
+                        performanceCounterInfos.Add(new PerformanceCounterInfo(name, performanceCounter, counter.FieldName, counter.Alias, counter.Tags));
                     }
                 }
                 else
                 {
-                    performanceCounterInfos.Add(new PerformanceCounterInfo(counter.Name, null, counter.Alias, counter.Tags));
+                    performanceCounterInfos.Add(new PerformanceCounterInfo(counter.Name, null, counter.FieldName, counter.Alias, counter.Tags));
                 }
             }
             return performanceCounterInfos;

--- a/Tharga.Influx-Capacitor.Collector/Entities/Counter.cs
+++ b/Tharga.Influx-Capacitor.Collector/Entities/Counter.cs
@@ -9,19 +9,21 @@ namespace Tharga.InfluxCapacitor.Collector.Entities
         private readonly string _categoryName;
         private readonly string _counterName;
         private readonly string _instanceName;
+        private readonly string _fieldName;
         private readonly string _alias;
         private readonly List<ITag> _tags;
 
         public Counter(string categoryName, string counterName)
-            : this(categoryName, counterName, string.Empty, null, null)
+            : this(categoryName, counterName, string.Empty, null, null, null)
         {
         }
 
-        public Counter(string categoryName, string counterName, string instanceName, string alias, IEnumerable<ITag> tags)
+        public Counter(string categoryName, string counterName, string instanceName, string fieldName, string alias, IEnumerable<ITag> tags)
         {
             _categoryName = categoryName;
             _counterName = counterName;
             _instanceName = instanceName;
+            _fieldName = fieldName;
             _alias = alias;
             _tags = (tags ?? new List<ITag>()).ToList();
         }
@@ -30,6 +32,7 @@ namespace Tharga.InfluxCapacitor.Collector.Entities
         public string CategoryName { get { return _categoryName; } }
         public string CounterName { get { return _counterName; } }
         public string InstanceName { get { return _instanceName; } }
+        public string FieldName { get { return _fieldName; } }
         public string Alias { get { return _alias; } }
         public IEnumerable<ITag> Tags { get { return _tags; } }
     }

--- a/Tharga.Influx-Capacitor.Collector/Entities/PerformanceCounterInfo.cs
+++ b/Tharga.Influx-Capacitor.Collector/Entities/PerformanceCounterInfo.cs
@@ -10,18 +10,21 @@ namespace Tharga.InfluxCapacitor.Collector.Entities
         private readonly string _name;
         private readonly PerformanceCounter _performanceCounters;
         private readonly string _alias;
+        private readonly string _fieldName;
         private readonly List<ITag> _tags;
 
-        public PerformanceCounterInfo(string name, PerformanceCounter performanceCounters, string alias, IEnumerable<ITag> tags)
+        public PerformanceCounterInfo(string name, PerformanceCounter performanceCounters, string fieldName, string alias, IEnumerable<ITag> tags)
         {
             _name = name;
             _performanceCounters = performanceCounters;
+            _fieldName = fieldName;
             _alias = alias;
             _tags = (tags ?? new List<ITag>()).ToList();
         }
 
         public string Name { get { return _name; } }
         public PerformanceCounter PerformanceCounter { get { return _performanceCounters; } }
+        public string FieldName {  get { return _fieldName; } }
         public string Alias { get { return _alias; } }
         public IEnumerable<ITag> Tags { get { return _tags; } }
     }

--- a/Tharga.Influx-Capacitor.Collector/Handlers/DataInitiator.cs
+++ b/Tharga.Influx-Capacitor.Collector/Handlers/DataInitiator.cs
@@ -35,7 +35,7 @@ namespace Tharga.InfluxCapacitor.Collector.Handlers
         {
             var name = "processor";
 
-            var counters = new List<ICounter> { new Counter("Processor", "% Processor Time", "*", null, null) };
+            var counters = new List<ICounter> { new Counter("Processor", "% Processor Time", "*", null, null, null) };
             var response = new CounterGroup(name, 10, 0, counters, new ITag[] { }, CollectorEngineType.Safe);
             return ConvertErrorsToWarnings(CreateFile(name, response));
         }

--- a/Tharga.Influx-Capacitor.Collector/Interface/ICounter.cs
+++ b/Tharga.Influx-Capacitor.Collector/Interface/ICounter.cs
@@ -8,6 +8,7 @@ namespace Tharga.InfluxCapacitor.Collector.Interface
         string CategoryName { get; }
         string CounterName { get; }
         string InstanceName { get; }
+        string FieldName { get; }
         string Alias { get; }
         IEnumerable<ITag> Tags { get; }
     }

--- a/Tharga.Influx-Capacitor.Collector/Interface/IPerformanceCounterInfo.cs
+++ b/Tharga.Influx-Capacitor.Collector/Interface/IPerformanceCounterInfo.cs
@@ -7,6 +7,7 @@ namespace Tharga.InfluxCapacitor.Collector.Interface
     {
         string Name { get; }
         PerformanceCounter PerformanceCounter { get; }
+        string FieldName { get; }
         string Alias { get; }
         IEnumerable<ITag> Tags { get; }
     }

--- a/Tharga.Influx-Capacitor.Console/Commands/Counter/CounterCreateCommand.cs
+++ b/Tharga.Influx-Capacitor.Console/Commands/Counter/CounterCreateCommand.cs
@@ -42,9 +42,11 @@ namespace Tharga.InfluxCapacitor.Console.Commands.Counter
                     instanceName = QueryParam("Instance", GetParam(paramList, index++), instanceNames.Select(x => new KeyValuePair<string, string>(x, x)));
                 }
 
+                var fieldName = QueryParam<string>("FieldName", GetParam(paramList, index++));
+
                 addAnother = QueryParam("Add another counter?", GetParam(paramList, index++), new Dictionary<bool, string> { { true, "Yes" }, { false, "No" } });
 
-                var collector = new Collector.Entities.Counter(categoryName, counterName, instanceName, null, null);
+                var collector = new Collector.Entities.Counter(categoryName, counterName, instanceName, fieldName, null, null);
                 collectors.Add(collector);
             }
 


### PR DESCRIPTION
This PR allows users to use a new configuration option, named FieldName which will enable a more compact schema for points sent to InfluxDB

I recommend you read the README.md diff to better understand this changes. But first, I want to precise that this PR is backward compatible, and the only modified behavior is in `CollectorEngineBase.FormatResult` method.