### PR TITLE
Hide performance counter instance inside IPerformanceCounterInfo

### DIFF
--- a/Tharga.Influx-Capacitor.Collector/Entities/PerformanceCounterGroup.cs
+++ b/Tharga.Influx-Capacitor.Collector/Entities/PerformanceCounterGroup.cs
@@ -91,12 +91,12 @@ namespace Tharga.InfluxCapacitor.Collector.Entities
                     //Get a new list of counters. Add new ones and remove obsolete ones. (Do not refresh the entire list since that messes up the metrics)
                     var cnt = _performanceCounterInfos.Count;
 
-                    _performanceCounterInfos.RemoveAll(x => x.PerformanceCounter == null);
-                    _performanceCounterInfos.RemoveAll(x => !newPerformanceCounterInfos.Any(y => y.Name == x.Name && y.PerformanceCounter.CategoryName == x.PerformanceCounter.CategoryName && y.PerformanceCounter.CounterName == x.PerformanceCounter.CounterName && y.PerformanceCounter.InstanceName == x.PerformanceCounter.InstanceName));
+                    _performanceCounterInfos.RemoveAll(x => x.HasPerformanceCounter);
+                    _performanceCounterInfos.RemoveAll(x => !newPerformanceCounterInfos.Any(y => y.Name == x.Name && y.CategoryName == x.CategoryName && y.CounterName == x.CounterName && y.InstanceName == x.InstanceName));
                     var removed = cnt - _performanceCounterInfos.Count;
                     cnt = _performanceCounterInfos.Count;
 
-                    var newCounters = newPerformanceCounterInfos.Where(x => !_performanceCounterInfos.Any(y => y.Name == x.Name && y.PerformanceCounter.CategoryName == x.PerformanceCounter.CategoryName && y.PerformanceCounter.CounterName == x.PerformanceCounter.CounterName && y.PerformanceCounter.InstanceName == x.PerformanceCounter.InstanceName));
+                    var newCounters = newPerformanceCounterInfos.Where(x => !_performanceCounterInfos.Any(y => y.Name == x.Name && y.CategoryName == x.CategoryName && y.CounterName == x.CounterName && y.InstanceName == x.InstanceName));
                     _performanceCounterInfos = _performanceCounterInfos.Union(newCounters).ToList();
                     var added = _performanceCounterInfos.Count - cnt;
 

--- a/Tharga.Influx-Capacitor.Collector/Entities/PerformanceCounterInfo.cs
+++ b/Tharga.Influx-Capacitor.Collector/Entities/PerformanceCounterInfo.cs
@@ -40,10 +40,22 @@ namespace Tharga.InfluxCapacitor.Collector.Entities
         }
 
         public string Name { get { return _name; } }
-        public PerformanceCounter PerformanceCounter { get { return _performanceCounters; } }
+
+        public string CounterName { get { return _performanceCounters.CounterName; } }
+        
+        public string CategoryName {  get { return _performanceCounters.CategoryName; } }
+        
+        public string InstanceName {  get { return _performanceCounters.InstanceName; } }
+
         public string FieldName {  get { return _fieldName; } }
         public string Alias { get { return _alias; } }
         public IEnumerable<ITag> Tags { get { return _tags; } }
         public float? Max { get { return _max; } }
+
+        public bool HasPerformanceCounter {  get { return _performanceCounters != null; } }
+        public float NextValue()
+        {
+            return _performanceCounters.NextValue();
+        }
     }
 }

--- a/Tharga.Influx-Capacitor.Collector/Handlers/CollectorEngineBase.cs
+++ b/Tharga.Influx-Capacitor.Collector/Handlers/CollectorEngineBase.cs
@@ -161,7 +161,7 @@ namespace Tharga.InfluxCapacitor.Collector.Handlers
                 try
                 {
                     var infos = performanceCounterInfos[i];
-                    var value = infos.PerformanceCounter.NextValue();
+                    var value = infos.NextValue();
 
                     // if the counter value is greater than the max limit, then we use the max value
                     // see https://support.microsoft.com/en-us/kb/310067
@@ -212,7 +212,7 @@ namespace Tharga.InfluxCapacitor.Collector.Handlers
                 {
                     var performanceCounterInfo = performanceCounterInfos[i];
                     var fieldName = performanceCounterInfo.FieldName ?? "value";
-                    var key = performanceCounterInfo.PerformanceCounter.InstanceName;
+                    var key = performanceCounterInfo.InstanceName;
 
                     Dictionary<string, object> fields;
                     if (!valuesByInstance.TryGetValue(key ?? string.Empty, out fields))
@@ -259,9 +259,9 @@ namespace Tharga.InfluxCapacitor.Collector.Handlers
                 {
                     var performanceCounterInfo = performanceCounterInfos[i];
 
-                    var categoryName = performanceCounterInfo.PerformanceCounter.CategoryName;
-                    var counterName = performanceCounterInfo.PerformanceCounter.CounterName;
-                    var key = performanceCounterInfo.PerformanceCounter.InstanceName;
+                    var categoryName = performanceCounterInfo.CategoryName;
+                    var counterName = performanceCounterInfo.CounterName;
+                    var key = performanceCounterInfo.InstanceName;
                     var instanceAlias = performanceCounterInfo.Alias;
                     var tags = GetTags(Tags.Union(performanceCounterInfo.Tags), categoryName, counterName);
                     var fields = new Dictionary<string, object>

--- a/Tharga.Influx-Capacitor.Collector/Interface/IPerformanceCounterInfo.cs
+++ b/Tharga.Influx-Capacitor.Collector/Interface/IPerformanceCounterInfo.cs
@@ -1,14 +1,39 @@
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace Tharga.InfluxCapacitor.Collector.Interface
 {
     public interface IPerformanceCounterInfo
     {
+        /// <summary>
+        /// Gets the name of this informational counter.
+        /// Can be <see cref="CounterName"/> or <see cref="InstanceName"/>, depending if <see cref="CounterName"/> value is "*".
+        /// </summary>
         string Name { get; }
-        PerformanceCounter PerformanceCounter { get; }
+
+        /// <summary>
+        /// Gets a value indicating if this informational counter has a real counter or not.
+        /// </summary>
+        bool HasPerformanceCounter { get; }
+
+        /// <summary>
+        /// Gets the category this performance counter is member of.
+        /// </summary>
+        string CategoryName { get; }
+
+        /// <summary>
+        /// Gets the performance counter name.
+        /// </summary>
+        string CounterName { get; }
+
+        /// <summary>
+        /// Gets the instance name for this counter.
+        /// </summary>
+        string InstanceName { get; }
+
         string FieldName { get; }
+
         string Alias { get; }
+
         IEnumerable<ITag> Tags { get; }
 
         /// <summary>
@@ -18,5 +43,10 @@ namespace Tharga.InfluxCapacitor.Collector.Interface
         /// <seealso cref="ICounter.Max"/>
         /// <seealso href="https://support.microsoft.com/en-us/kb/310067"/>
         float? Max { get; }
+
+        /// <summary>
+        /// Obtains the next counter value and returns it.
+        /// </summary>
+        float NextValue();
     }
 }

--- a/Tharga.Influx-Capacitor.Console/Commands/Counter/CounterCommandBase.cs
+++ b/Tharga.Influx-Capacitor.Console/Commands/Counter/CounterCommandBase.cs
@@ -15,10 +15,10 @@ namespace Tharga.InfluxCapacitor.Console.Commands.Counter
             var count = 0;
             foreach (var counter in counterGroup.GetFreshCounters())
             {
-                if (counter.PerformanceCounter != null)
+                if (counter.HasPerformanceCounter)
                 {
-                    var nextValue = counter.PerformanceCounter.NextValue();
-                    OutputInformation("{0}.{1}.{2} {3}:\t{4}", counter.PerformanceCounter.CategoryName, counter.PerformanceCounter.CounterName, counter.PerformanceCounter.InstanceName, counter.Name, nextValue);
+                    var nextValue = counter.NextValue();
+                    OutputInformation("{0}.{1}.{2} {3}:\t{4}", counter.CategoryName, counter.CounterName, counter.InstanceName, counter.Name, nextValue);
                     count++;
                 }
                 else

--- a/Tharga.Influx-Capacitor.Console/Commands/Counter/CounterListCommand.cs
+++ b/Tharga.Influx-Capacitor.Console/Commands/Counter/CounterListCommand.cs
@@ -28,9 +28,9 @@ namespace Tharga.InfluxCapacitor.Console.Commands.Counter
                 OutputInformation("{0}", counterGroup.Name);
                 foreach (var counter in counterGroup.GetFreshCounters())
                 {
-                    if (counter.PerformanceCounter != null)
+                    if (counter.HasPerformanceCounter)
                     {
-                        OutputInformation("   OK\t{0}.{1}.{2} {3}", counter.PerformanceCounter.CategoryName, counter.PerformanceCounter.CounterName, counter.PerformanceCounter.InstanceName, counter.Name);
+                        OutputInformation("   OK\t{0}.{1}.{2} {3}", counter.CategoryName, counter.CounterName, counter.InstanceName, counter.Name);
                         cnt++;
                     }
                     else


### PR DESCRIPTION
Just a small refactoring PR. Was considering this when testing around IPerformanceCounterInfo.

This way, IPerformanceCounterInfo can be easily mocked for testing purposes.