### PR TITLE
add option to allow duplicate PerformanceCounters instance names

### DIFF
--- a/Tharga.Influx-Capacitor.Collector/Business/ConfigBusiness.cs
+++ b/Tharga.Influx-Capacitor.Collector/Business/ConfigBusiness.cs
@@ -488,7 +488,7 @@ namespace Tharga.InfluxCapacitor.Collector.Business
             if (!bool.TryParse(stringValue, out value))
             {
                 if (defaultValue == null)
-                    throw new InvalidOperationException(string.Format("Cannot parse attribute {0} value to integer.", name));
+                    throw new InvalidOperationException(string.Format("Cannot parse attribute {0} value to bool.", name));
                 return defaultValue.Value;
             }
 

--- a/Tharga.Influx-Capacitor.Collector/Business/ConfigBusiness.cs
+++ b/Tharga.Influx-Capacitor.Collector/Business/ConfigBusiness.cs
@@ -405,6 +405,7 @@ namespace Tharga.InfluxCapacitor.Collector.Business
             var refreshInstanceInterval = GetInt(counterGroup, "RefreshInstanceInterval", 0);
             var collectorEngineType = GetString(counterGroup, "CollectorEngineType", "Safe");
             var providerName = GetString(counterGroup, "Provider", string.Empty);
+            var allowDuplicateInstanceNames = GetBool(counterGroup, "AllowDuplicateInstanceNames", false);
 
             var counters = counterGroup.GetElementsByTagName("Counter");
             var cts = new List<ICounter>();
@@ -450,7 +451,7 @@ namespace Tharga.InfluxCapacitor.Collector.Business
                 cet = CollectorEngineType.Safe;
             }
 
-            return new CounterGroup(name, secondsInterval, refreshInstanceInterval, cts, tags, cet, filters, providerName);
+            return new CounterGroup(name, secondsInterval, refreshInstanceInterval, cts, tags, cet, filters, providerName, allowDuplicateInstanceNames);
         }
 
         private static string GetString(XmlElement element, string name, string defaultValue = null)
@@ -471,6 +472,20 @@ namespace Tharga.InfluxCapacitor.Collector.Business
             var stringValue = GetString(element, name, defaultValue != null ? defaultValue.ToString() : null);
             int value;
             if (!int.TryParse(stringValue, out value))
+            {
+                if (defaultValue == null)
+                    throw new InvalidOperationException(string.Format("Cannot parse attribute {0} value to integer.", name));
+                return defaultValue.Value;
+            }
+
+            return value;
+        }
+
+        private static bool GetBool(XmlElement element, string name, bool? defaultValue = null)
+        {
+            var stringValue = GetString(element, name, defaultValue != null ? defaultValue.ToString() : null);
+            bool value;
+            if (!bool.TryParse(stringValue, out value))
             {
                 if (defaultValue == null)
                     throw new InvalidOperationException(string.Format("Cannot parse attribute {0} value to integer.", name));

--- a/Tharga.Influx-Capacitor.Collector/Business/PerformanceCounterProvider.cs
+++ b/Tharga.Influx-Capacitor.Collector/Business/PerformanceCounterProvider.cs
@@ -96,17 +96,20 @@ namespace Tharga.InfluxCapacitor.Collector.Business
                         // because of the filtering, multiples instances can have the same instance name,
                         // so we increment a counter for each instance after the first one
                         // eg: w3wp, w3wp#2, w3wp#3, etc.
-                        var filteredNames = new Dictionary<string, int>(StringComparer.Ordinal);
-                        for (var i = 0; i < performanceCounters.Count; i++)
+                        if (!group.AllowDuplicateInstanceNames)
                         {
-                            int count;
-                            var instanceName = performanceCounters[i].InstanceName;
-                            if (filteredNames.TryGetValue(instanceName, out count))
+                            var filteredNames = new Dictionary<string, int>(StringComparer.Ordinal);
+                            for (var i = 0; i < performanceCounters.Count; i++)
                             {
-                                performanceCounters[i].InstanceName = instanceName + "#" + (count + 1);
-                            }
+                                int count;
+                                var instanceName = performanceCounters[i].InstanceName;
+                                if (filteredNames.TryGetValue(instanceName, out count))
+                                {
+                                    performanceCounters[i].InstanceName = instanceName + "#" + (count + 1);
+                                }
 
-                            filteredNames[instanceName] = count + 1;
+                                filteredNames[instanceName] = count + 1;
+                            }
                         }
                     }
 

--- a/Tharga.Influx-Capacitor.Collector/Entities/CounterGroup.cs
+++ b/Tharga.Influx-Capacitor.Collector/Entities/CounterGroup.cs
@@ -13,10 +13,11 @@ namespace Tharga.InfluxCapacitor.Collector.Entities
         private readonly List<ICounter> _counters;
         private readonly List<ITag> _tags;
         private readonly CollectorEngineType _collectorEngineType;
-        private readonly IEnumerable<ICounterInstanceFilter> _filters ;
+        private readonly IEnumerable<ICounterInstanceFilter> _filters;
         private readonly string _provider;
+        private readonly bool _allowDuplicateInstanceNames;
 
-        public CounterGroup(string name, int secondsInterval, int refreshInstanceInterval, List<ICounter> counters, IEnumerable<ITag> tags, CollectorEngineType collectorEngineType, IEnumerable<ICounterInstanceFilter> filters, string provider)
+        public CounterGroup(string name, int secondsInterval, int refreshInstanceInterval, List<ICounter> counters, IEnumerable<ITag> tags, CollectorEngineType collectorEngineType, IEnumerable<ICounterInstanceFilter> filters, string provider, bool allowDuplicateInstanceNames)
         {
             _name = name;
             _secondsInterval = secondsInterval;
@@ -26,6 +27,7 @@ namespace Tharga.InfluxCapacitor.Collector.Entities
             _collectorEngineType = collectorEngineType;
             _filters = filters;
             _provider = provider;
+            _allowDuplicateInstanceNames = allowDuplicateInstanceNames;
         }
 
         public string Name { get { return _name; } }
@@ -34,7 +36,8 @@ namespace Tharga.InfluxCapacitor.Collector.Entities
         public IEnumerable<ICounter> Counters { get { return _counters; } }
         public IEnumerable<ITag> Tags { get { return _tags; } }
         public CollectorEngineType CollectorEngineType { get { return _collectorEngineType; } }
-        public IEnumerable<ICounterInstanceFilter> Filters { get { return _filters; } } 
+        public bool AllowDuplicateInstanceNames { get { return _allowDuplicateInstanceNames; } }
+        public IEnumerable<ICounterInstanceFilter> Filters { get { return _filters; } }
         public string Provider { get { return _provider; } }
     }
 }

--- a/Tharga.Influx-Capacitor.Collector/Handlers/DataInitiator.cs
+++ b/Tharga.Influx-Capacitor.Collector/Handlers/DataInitiator.cs
@@ -26,7 +26,7 @@ namespace Tharga.InfluxCapacitor.Collector.Handlers
 
         public Tuple<string, Tuple<string, OutputLevel>> CreateCounter(string groupName, int secondsInterval, int refreshInstanceInterval, List<ICounter> counters, CollectorEngineType collectorEngineType)
         {
-            var response = new CounterGroup(groupName, secondsInterval, refreshInstanceInterval, counters, new ITag[] { }, collectorEngineType, null, null);
+            var response = new CounterGroup(groupName, secondsInterval, refreshInstanceInterval, counters, new ITag[] { }, collectorEngineType, null, null, false);
             var message = CreateFile(groupName, response);
             return new Tuple<string, Tuple<string, OutputLevel>>(groupName, message);
         }
@@ -36,7 +36,7 @@ namespace Tharga.InfluxCapacitor.Collector.Handlers
             var name = "processor";
 
             var counters = new List<ICounter> { new Counter("Processor", "% Processor Time", "*", null, null, null, null, null) };
-            var response = new CounterGroup(name, 10, 0, counters, new ITag[] { }, CollectorEngineType.Safe, null, null);
+            var response = new CounterGroup(name, 10, 0, counters, new ITag[] { }, CollectorEngineType.Safe, null, null, false);
             return ConvertErrorsToWarnings(CreateFile(name, response));
         }
 
@@ -45,7 +45,7 @@ namespace Tharga.InfluxCapacitor.Collector.Handlers
             var name = "memory";
             
             var counters = new List<ICounter> { new Counter("Memory", "*", string.Empty, null, null, null, null, null) };
-            var response = new CounterGroup(name, 10, 0, counters, new ITag[] { }, CollectorEngineType.Safe, null, null);
+            var response = new CounterGroup(name, 10, 0, counters, new ITag[] { }, CollectorEngineType.Safe, null, null, false);
             return ConvertErrorsToWarnings(CreateFile(name, response));
         }
 

--- a/Tharga.Influx-Capacitor.Collector/Interface/ICounterGroup.cs
+++ b/Tharga.Influx-Capacitor.Collector/Interface/ICounterGroup.cs
@@ -12,6 +12,7 @@ namespace Tharga.InfluxCapacitor.Collector.Interface
         IEnumerable<ICounter> Counters { get; }
         IEnumerable<ITag> Tags { get; }
         CollectorEngineType CollectorEngineType { get; }
+        bool AllowDuplicateInstanceNames { get; }
 
         /// <summary>
         /// Gets all filters defined on this group that should be applied on instance names.


### PR DESCRIPTION
By default, Influx-Capacitor will append "#n" (where n is an incrementing integer) to the end of a PerformanceCounter instance name if it detects that there is another with the same name. To disable this functionality, you simply add AllowDuplicateInstanceNames="true" to a CounterGroup in the XML configuration.